### PR TITLE
ruby v2.6-rc, j2cli drop-in replacement by p2cli

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,7 +1,9 @@
-FROM ruby:2.5-alpine
+FROM ruby:2.6-rc-alpine
 
-RUN apk --no-cache add nodejs mariadb-client git bash python2 libcap py-setuptools py-pip build-base mariadb-dev tzdata mariadb-client-libs \
-	&& pip install j2cli \
+RUN wget https://github.com/wrouesnel/p2cli/releases/download/r5/p2 -O /usr/local/bin/p2 \
+        && chmod +x /usr/local/bin/p2
+
+RUN apk --no-cache add nodejs mariadb-client git bash libcap build-base mariadb-dev tzdata mariadb-client-libs \
         && git clone https://github.com/atech/postal.git /opt/postal \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& gem install bundler \
@@ -25,4 +27,5 @@ ADD src/templates /templates
 EXPOSE 5000
 
 ## Startup
+# ENV RUBYOPT --jit
 ENTRYPOINT ["/bin/bash", "-c", "/docker-entrypoint.sh ${*}", "--"]

--- a/alpine/src/docker-entrypoint.sh
+++ b/alpine/src/docker-entrypoint.sh
@@ -3,7 +3,7 @@
 ## Generate config
 if [ ! -f /opt/postal/config/postal.yml ] || [[ $(cat /opt/postal/config/postal.yml | wc -l) < 2 ]]; then
 	## Build Jinja2 Template
-	j2 /templates/postal.example.yml.j2 > /opt/postal/config/postal.example.yml
+	p2 -t /templates/postal.example.yml.j2 -o /opt/postal/config/postal.example.yml
 	## Add in secret key building
 	echo "rails:" >> /opt/postal/config/postal.example.yml
 	echo "  secret_key: {{secretkey}}" >> /opt/postal/config/postal.example.yml

--- a/alpine/src/nginx.conf
+++ b/alpine/src/nginx.conf
@@ -9,7 +9,7 @@ server {
     }
 
     location /assets {
-        add_header Cache-Control max-age=3600;
+        add_header Cache-Control "public,max-age=3600,immutable";
     }
 
     location @puma {

--- a/alpine/src/nginx.conf
+++ b/alpine/src/nginx.conf
@@ -1,17 +1,15 @@
 server {
     listen 80;
-
     root /opt/postal/public;
-
+    gzip_static on;
+    gzip_proxied any;
     location / {
         client_max_body_size 50M;
         try_files $uri $uri/index.html $uri.html @puma;
     }
-
     location /assets {
         add_header Cache-Control "public,max-age=3600,immutable";
     }
-
     location @puma {
         proxy_set_header X-Real-IP  $remote_addr;
         proxy_set_header Host $host;

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -1,8 +1,13 @@
-FROM ruby:2.4
+FROM ruby:2.6-rc
+
+RUN curl -L https://github.com/wrouesnel/p2cli/releases/download/r5/p2 -o /usr/local/bin/p2 \
+        && chmod +x /usr/local/bin/p2
+
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
+        && apt-get install -y nodejs
 
 RUN apt-get -y update \
-	&& apt-get -y install --no-install-recommends nodejs mysql-client git-core python-minimal python-pip python-dev libcap2-bin python-setuptools \
-	&& pip install j2cli \
+	&& apt-get -y install --no-install-recommends nodejs mysql-client git-core libcap2-bin \
         && git clone https://github.com/atech/postal.git /opt/postal \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& gem install bundler \
@@ -26,4 +31,5 @@ ADD src/templates /templates
 EXPOSE 5000
 
 ## Startup
+# ENV RUBYOPT --jit
 ENTRYPOINT ["/bin/bash", "-c", "/docker-entrypoint.sh ${*}", "--"]

--- a/ubuntu/src/docker-entrypoint.sh
+++ b/ubuntu/src/docker-entrypoint.sh
@@ -3,7 +3,7 @@
 ## Generate config
 if [ ! -f /opt/postal/config/postal.yml ] || [[ $(cat /opt/postal/config/postal.yml | wc -l) < 2 ]]; then
 	## Build Jinja2 Template
-	j2 /templates/postal.example.yml.j2 > /opt/postal/config/postal.example.yml
+	p2 -t /templates/postal.example.yml.j2 -o /opt/postal/config/postal.example.yml
 	## Add in secret key building
 	echo "rails:" >> /opt/postal/config/postal.example.yml
 	echo "  secret_key: {{secretkey}}" >> /opt/postal/config/postal.example.yml

--- a/ubuntu/src/nginx.conf
+++ b/ubuntu/src/nginx.conf
@@ -9,7 +9,7 @@ server {
     }
 
     location /assets {
-        add_header Cache-Control max-age=3600;
+        add_header Cache-Control "public,max-age=3600,immutable";
     }
 
     location @puma {

--- a/ubuntu/src/nginx.conf
+++ b/ubuntu/src/nginx.conf
@@ -1,17 +1,15 @@
 server {
     listen 80;
-
     root /opt/postal/public;
-
+    gzip_static on;
+    gzip_proxied any;
     location / {
         client_max_body_size 50M;
         try_files $uri $uri/index.html $uri.html @puma;
     }
-
     location /assets {
         add_header Cache-Control "public,max-age=3600,immutable";
     }
-
     location @puma {
         proxy_set_header X-Real-IP  $remote_addr;
         proxy_set_header Host $host;


### PR DESCRIPTION
* j2cli replaced by p2cli (https://github.com/wrouesnel/p2cli).
  - Python is removed, not needed.
* Ruby 2.6-rc (Alpine & Ubuntu).