### PR TITLE
Updated PID clean up for postal app

### DIFF
--- a/alpine/src/docker-entrypoint.sh
+++ b/alpine/src/docker-entrypoint.sh
@@ -14,7 +14,7 @@ cat /opt/postal/config/postal.yml
 
 ## Clean Up
 rm -rf /opt/postal/tmp/pids/*
-
+rm -rf /tmp/postal
 ## Wait for MySQL to start up
 echo "== Waiting for MySQL to start up =="
 while ! mysqladmin ping -h mysql --silent; do

--- a/ubuntu/src/docker-entrypoint.sh
+++ b/ubuntu/src/docker-entrypoint.sh
@@ -14,7 +14,7 @@ cat /opt/postal/config/postal.yml
 
 ## Clean Up
 rm -rf /opt/postal/tmp/pids/*
-
+rm -rf /tmp/postal
 ## Wait for MySQL to start up
 echo "== Waiting for MySQL to start up =="
 while ! mysqladmin ping -h mysql --silent; do


### PR DESCRIPTION
Postal uses a supervisor which leaves abandoned PID files when we stop the container. This is due to SIGTERM only being send to PID1 which kills entrypoint.sh but nothing else, so postal is stopped dirty. an ideal solution would be to get the SIGTERM to the supervisor PID allowing postal to shut down gracefully. 