### PR TITLE
Implemented support for Ruby 2.7+/3.0+

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6-alpine
+FROM ruby:2.7-alpine
 
 ENV DOCKERIZE_VERSION v0.6.1
 
@@ -7,6 +7,7 @@ RUN wget https://github.com/wrouesnel/p2cli/releases/download/r5/p2 -O /usr/loca
 
 RUN apk --no-cache add nodejs mariadb-client git bash libcap build-base mariadb-dev tzdata mariadb-connector-c openssl expect\
         && git clone https://github.com/atech/postal.git /opt/postal \
+        && sed -i 's/1.17.2/2.1.4/g' /opt/postal/Gemfile.lock \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& gem install bundler \
 	&& gem install procodile \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -36,6 +36,23 @@ ADD src/templates /templates
 # NGINX (X-Accel-Redirect)
 RUN sed -i '/config.action_dispatch.x_sendfile_header/s/^# //g' /opt/postal/config/environments/production.rb
 
+# Protection against identification by automatic bots on vulnerability
+ENV REBRAND_MAILER=MySendClient
+RUN if [ ! -z "${REBRAND_MAILER}" ]; then \
+           sed -i -E "s@(by )Postal@\1${REBRAND_MAILER}@g" /opt/postal/app/models/*message*.rb; \
+           sed -i -E "s@(X(\\\)?-)Postal@\1${REBRAND_MAILER}@g" /opt/postal/lib/postal/message_db/message.rb; \
+           sed -i -E "s@(ESMTP )Postal@\1${REBRAND_MAILER}@g" /opt/postal/lib/postal/smtp_server/server.rb; \
+           sed -i -E "s@(ESMTP )Postal@\1${REBRAND_MAILER}@g" /opt/postal/lib/postal/smtp_server/client.rb; \
+           sed -i "s@Welcome to Postal@Welcome to ${REBRAND_MAILER}@g" /opt/postal/app/mailers/app_mailer.rb; \
+           sed -i "s@Welcome to Postal@Welcome to ${REBRAND_MAILER}@g" /opt/postal/lib/postal/smtp_server/server.rb; \
+           sed -i "s@Welcome to Postal@Welcome to ${REBRAND_MAILER}@g" /opt/postal/app/views/organizations/index.html.haml; \
+           sed -i "s@Welcome to Postal@Welcome to ${REBRAND_MAILER}@g" /opt/postal/app/views/user/join.html.haml; \
+           sed -i "s@Welcome to Postal@Welcome to ${REBRAND_MAILER}@g" /opt/postal/app/views/sessions/new.html.haml; \
+           sed -i "s@\[\"Postal\"\]@\[\"${REBRAND_MAILER}\"\]@g" /opt/postal/app/controllers/application_controller.rb; \
+           # bash -c "sed -i \"s@_postal_session@_${REBRAND_MAILER}_session@g\" /opt/postal/config/initializers/session_store.rb"; \
+           sed -i "s@_postal_session@_$(echo -n ${REBRAND_MAILER}|tr '[:upper:]' '[:lower:]')_session@g" /opt/postal/config/initializers/session_store.rb; \
+         fi
+
 ## Expose
 EXPOSE 5000
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,5 @@
 FROM ruby:2.7-alpine
+#FROM ruby:3.0-rc-alpine # && sed -i 's@minitest (5.14.1)@minitest (5.14.2)@g' /opt/postal/Gemfile.lock
 
 ENV DOCKERIZE_VERSION v0.6.1
 
@@ -31,6 +32,9 @@ RUN setcap 'cap_net_bind_service=+ep' /usr/local/bin/ruby
 ADD src/docker-entrypoint.sh /docker-entrypoint.sh
 ADD src/create-user.sh /create-user.sh
 ADD src/templates /templates
+
+# NGINX (X-Accel-Redirect)
+RUN sed -i '/config.action_dispatch.x_sendfile_header/s/^# //g' /opt/postal/config/environments/production.rb
 
 ## Expose
 EXPOSE 5000

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,5 +1,7 @@
 FROM ruby:2.7-alpine
 #FROM ruby:3.0-rc-alpine # && sed -i 's@minitest (5.14.1)@minitest (5.14.2)@g' /opt/postal/Gemfile.lock
+#FROM flavorjones/truffleruby:stable
+#FROM jruby:9.2
 
 ENV DOCKERIZE_VERSION v0.6.1
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -6,7 +6,7 @@ ENV DOCKERIZE_VERSION v0.6.1
 RUN wget https://github.com/wrouesnel/p2cli/releases/download/r5/p2 -O /usr/local/bin/p2 \
         && chmod +x /usr/local/bin/p2
 
-RUN apk --no-cache add nodejs mariadb-client git bash libcap build-base mariadb-dev tzdata mariadb-connector-c openssl expect\
+RUN apk --no-cache add nodejs mariadb-client git bash libcap build-base mariadb-dev tzdata mariadb-connector-c openssl expect libjemalloc2 \
         && git clone --depth=1 https://github.com/atech/postal.git /opt/postal \
         && sed -i 's/1.17.2/2.1.4/g' /opt/postal/Gemfile.lock \
 	&& rm -rf /var/lib/apt/lists/* \
@@ -57,5 +57,7 @@ RUN if [ ! -z "${REBRAND_MAILER}" ]; then \
 EXPOSE 5000
 
 ## Startup
-# ENV RUBYOPT --jit
+ENV RUBYOPT --jit
+# ENV MALLOC_ARENA_MAX 2
+ENV LD_PRELOAD /usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 ENTRYPOINT ["/bin/bash", "-c", "/docker-entrypoint.sh ${*}", "--"]

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -6,7 +6,7 @@ RUN wget https://github.com/wrouesnel/p2cli/releases/download/r5/p2 -O /usr/loca
         && chmod +x /usr/local/bin/p2
 
 RUN apk --no-cache add nodejs mariadb-client git bash libcap build-base mariadb-dev tzdata mariadb-connector-c openssl expect\
-        && git clone https://github.com/atech/postal.git /opt/postal \
+        && git clone --depth=1 https://github.com/atech/postal.git /opt/postal \
         && sed -i 's/1.17.2/2.1.4/g' /opt/postal/Gemfile.lock \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& gem install bundler \

--- a/alpine/docker-compose.yml
+++ b/alpine/docker-compose.yml
@@ -33,6 +33,8 @@ services:
   mysql:
     image: mariadb:10
     container_name: postal_mysql
+    command: |
+      mysqld --thread-handling=pool-of-threads
     volumes:
       - mysql_data:/var/lib/mysql
     environment:

--- a/alpine/src/create-user.sh
+++ b/alpine/src/create-user.sh
@@ -1,11 +1,15 @@
 #!/usr/bin/expect
 eval spawn /opt/postal/bin/postal make-user
 expect "E-Mail"
+sleep 1
 send "$env(POSTAL_EMAIL)\n"
 expect "First Name"
+sleep 1
 send "$env(POSTAL_FNAME)\n"
 expect "Last Name"
+sleep 1
 send "$env(POSTAL_LNAME)\n"
 expect "Password"
+sleep 1
 send "$env(POSTAL_PASSWORD)\n"
 interact

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -1,4 +1,5 @@
 FROM ruby:2.7
+#FROM ruby:3.0-rc # && sed -i 's@minitest (5.14.1)@minitest (5.14.2)@g' /opt/postal/Gemfile.lock
 
 ENV DOCKERIZE_VERSION v0.6.1
 
@@ -35,6 +36,9 @@ RUN setcap 'cap_net_bind_service=+ep' /usr/local/bin/ruby
 ADD src/docker-entrypoint.sh /docker-entrypoint.sh
 ADD src/create-user.sh /create-user.sh
 ADD src/templates /templates
+
+# NGINX (X-Accel-Redirect)
+RUN sed -i '/config.action_dispatch.x_sendfile_header/s/^# //g' /opt/postal/config/environments/production.rb
 
 ## Expose
 EXPOSE 5000

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6
+FROM ruby:2.7
 
 ENV DOCKERIZE_VERSION v0.6.1
 
@@ -11,6 +11,7 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
 RUN apt-get -y update \
 	&& apt-get -y install --no-install-recommends nodejs mariadb-client git-core libcap2-bin wget expect\
         && git clone https://github.com/atech/postal.git /opt/postal \
+        && sed -i 's/1.17.2/2.1.4/g' /opt/postal/Gemfile.lock \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& gem install bundler \
 	&& gem install procodile \

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -1,5 +1,7 @@
 FROM ruby:2.7
 #FROM ruby:3.0-rc # && sed -i 's@minitest (5.14.1)@minitest (5.14.2)@g' /opt/postal/Gemfile.lock
+#FROM flavorjones/truffleruby:stable
+#FROM jruby:9.2
 
 ENV DOCKERIZE_VERSION v0.6.1
 

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -10,7 +10,7 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
         && apt-get install -y nodejs
 
 RUN apt-get -y update \
-	&& apt-get -y install --no-install-recommends nodejs mariadb-client git-core libcap2-bin wget expect\
+	&& apt-get -y install --no-install-recommends nodejs mariadb-client git-core libcap2-bin wget expect libjemalloc2 \
         && git clone --depth=1 https://github.com/atech/postal.git /opt/postal \
         && sed -i 's/1.17.2/2.1.4/g' /opt/postal/Gemfile.lock \
 	&& rm -rf /var/lib/apt/lists/* \
@@ -61,5 +61,7 @@ RUN if [ ! -z "${REBRAND_MAILER}" ]; then \
 EXPOSE 5000
 
 ## Startup
-# ENV RUBYOPT --jit
+ENV RUBYOPT --jit
+# ENV MALLOC_ARENA_MAX 2
+ENV LD_PRELOAD /usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 ENTRYPOINT ["/bin/bash", "-c", "/docker-entrypoint.sh ${*}", "--"]

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -40,6 +40,23 @@ ADD src/templates /templates
 # NGINX (X-Accel-Redirect)
 RUN sed -i '/config.action_dispatch.x_sendfile_header/s/^# //g' /opt/postal/config/environments/production.rb
 
+# Protection against identification by automatic bots on vulnerability
+ENV REBRAND_MAILER=MySendClient
+RUN if [ ! -z "${REBRAND_MAILER}" ]; then \
+           sed -i -E "s@(by )Postal@\1${REBRAND_MAILER}@g" /opt/postal/app/models/*message*.rb; \
+           sed -i -E "s@(X(\\\)?-)Postal@\1${REBRAND_MAILER}@g" /opt/postal/lib/postal/message_db/message.rb; \
+           sed -i -E "s@(ESMTP )Postal@\1${REBRAND_MAILER}@g" /opt/postal/lib/postal/smtp_server/server.rb; \
+           sed -i -E "s@(ESMTP )Postal@\1${REBRAND_MAILER}@g" /opt/postal/lib/postal/smtp_server/client.rb; \
+           sed -i "s@Welcome to Postal@Welcome to ${REBRAND_MAILER}@g" /opt/postal/app/mailers/app_mailer.rb; \
+           sed -i "s@Welcome to Postal@Welcome to ${REBRAND_MAILER}@g" /opt/postal/lib/postal/smtp_server/server.rb; \
+           sed -i "s@Welcome to Postal@Welcome to ${REBRAND_MAILER}@g" /opt/postal/app/views/organizations/index.html.haml; \
+           sed -i "s@Welcome to Postal@Welcome to ${REBRAND_MAILER}@g" /opt/postal/app/views/user/join.html.haml; \
+           sed -i "s@Welcome to Postal@Welcome to ${REBRAND_MAILER}@g" /opt/postal/app/views/sessions/new.html.haml; \
+           sed -i "s@\[\"Postal\"\]@\[\"${REBRAND_MAILER}\"\]@g" /opt/postal/app/controllers/application_controller.rb; \
+           # bash -c "sed -i \"s@_postal_session@_${REBRAND_MAILER}_session@g\" /opt/postal/config/initializers/session_store.rb"; \
+           sed -i "s@_postal_session@_$(echo -n ${REBRAND_MAILER}|tr '[:upper:]' '[:lower:]')_session@g" /opt/postal/config/initializers/session_store.rb; \
+         fi
+
 ## Expose
 EXPOSE 5000
 

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -10,7 +10,7 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
 
 RUN apt-get -y update \
 	&& apt-get -y install --no-install-recommends nodejs mariadb-client git-core libcap2-bin wget expect\
-        && git clone https://github.com/atech/postal.git /opt/postal \
+        && git clone --depth=1 https://github.com/atech/postal.git /opt/postal \
         && sed -i 's/1.17.2/2.1.4/g' /opt/postal/Gemfile.lock \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& gem install bundler \

--- a/ubuntu/docker-compose.yml
+++ b/ubuntu/docker-compose.yml
@@ -35,6 +35,8 @@ services:
   mysql:
     image: mariadb:10
     container_name: postal_mysql
+    command: |
+      mysqld --thread-handling=pool-of-threads
     volumes:
       - mysql_data:/var/lib/mysql
     environment:

--- a/ubuntu/src/create-user.sh
+++ b/ubuntu/src/create-user.sh
@@ -1,11 +1,15 @@
 #!/usr/bin/expect
 eval spawn /opt/postal/bin/postal make-user
 expect "E-Mail"
+sleep 1
 send "$env(POSTAL_EMAIL)\n"
 expect "First Name"
+sleep 1
 send "$env(POSTAL_FNAME)\n"
 expect "Last Name"
+sleep 1
 send "$env(POSTAL_LNAME)\n"
 expect "Password"
+sleep 1
 send "$env(POSTAL_PASSWORD)\n"
 interact


### PR DESCRIPTION
* Ruby 2.7+ JIT is already much more stable
  - https://medium.com/@k0kubun/jit-development-progress-at-ruby-2-7-d6dd62a8c76a
  > `--jit-max-cache: 1,000 → 100`
  > `--jit-min-calls: 5 → 10,000`
* Ruby 2.7+ supports only bundle 2.0+
  - https://dev.to/st0012/completely-remove-the-default-bundler-from-ci-environment-j0c
* Instead please use `bundle config set clean 'true'`, and stop using this flag
  - https://github.com/postalhq/postal/blob/2595481/bin/postal#L107-L109

https://github.com/postalhq/postal/blob/2595481/config/environments/production.rb#L35